### PR TITLE
fix: keep embed iframe rendered (visibility) so it can fire loaded

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,30 @@
 2. View/sign account disclosures by clicking on the "Account Disclosures" tab in the nav bar:
    ![Yardstik](https://yardstik-assets.s3.amazonaws.com/images/embeddable-sdk-demo-disclosures.png)
 
+# Note: don't hide the iframe with `display: none`
+
+The SDK emits a `loaded` event once the embedded view has finished rendering. Hosts
+typically use it to hide a loading spinner and reveal the iframe:
+
+```jsx
+yardstikReport.on("loaded", () => setIframeReady(true));
+// ...
+<div
+  ref={containerRef}
+  style={{ visibility: iframeReady ? "visible" : "hidden" }}
+/>
+```
+
+**Do not gate the iframe with `display: none` while waiting for `loaded`.** A
+`display: none` subtree suspends rendering of the embedded app, so it never finishes
+rendering and therefore never posts the `loaded` message — the very signal you are
+waiting on. The result is a deadlock: the iframe stays on the spinner forever and the
+content never appears.
+
+Hide it with `visibility: hidden` (or `opacity: 0`) instead, which keeps the iframe
+rendered while hidden so it can finish loading and fire `loaded`. See
+`src/ReportView.jsx` and `src/AccountView.jsx` for the pattern used in this demo.
+
 # Viewing Any Other URL in an iFrame
 
 1. In addition to testing the Yardstik Embeddable-SDK library, this demo app can also be used to view any other URL that does not require authentication in an iFrame.

--- a/src/AccountView.jsx
+++ b/src/AccountView.jsx
@@ -86,7 +86,12 @@ function AccountView() {
       <div
         ref={containerRef}
         style={{
-          display: iframeReady ? "block" : "none",
+          // Do NOT use display:none to hide the iframe before it's ready: a
+          // display:none subtree suspends rendering of the embedded app, so it
+          // never finishes rendering and never fires `loaded` — the very signal
+          // that flips iframeReady. That deadlocks the load. visibility keeps
+          // it rendered while hidden, so it can load then reveal it.
+          visibility: iframeReady ? "visible" : "hidden",
           padding: "20px",
         }}
       />

--- a/src/ReportView.jsx
+++ b/src/ReportView.jsx
@@ -85,7 +85,12 @@ function ReportView() {
         sx={{
           bgcolor: "grey.200",
           height: "100%",
-          display: iframeReady ? "block" : "none",
+          // Do NOT use display:none to hide the iframe before it's ready: a
+          // display:none subtree suspends rendering of the embedded app, so it
+          // never finishes rendering and never fires `loaded` — the very signal
+          // that flips iframeReady. That deadlocks the load. visibility keeps
+          // it rendered while hidden, so it can load then reveal it.
+          visibility: iframeReady ? "visible" : "hidden",
           padding: "20px",
           "& iframe": { height: "90%", border: "none !important" },
         }}


### PR DESCRIPTION
## Description

Both `ReportView` and `AccountView` hid the embed container with `display: none` until the SDK's `loaded` event arrived. A `display:none` subtree suspends rendering of the embedded app, so it never finished rendering and therefore **never posted the `loaded` message** — the very signal that flips `iframeReady`. That deadlocked the load: the iframe stayed on the spinner forever and the content never appeared.

Fix: hide with `visibility: hidden` instead of `display: none`. The iframe still renders while hidden, fires `loaded`, and is then revealed.

- `src/ReportView.jsx`: `display` → `visibility`
- `src/AccountView.jsx`: `display` → `visibility`

Verified end-to-end on the report view: the report loads, `loaded` fires on its own, and the iframe is revealed — no manual intervention.

## Production-readiness

**Feature or ENV toggle this work is behind:**

`none` — trivial CSS-property swap in the demo host; no behavior change other than fixing the deadlock.

**New environment variables:**

- `none`

**Deploy tasks:**

- `none`

Related: surfaced while testing the embedded report `loaded` signal (core.frontend UX-1298). The same footgun affects any consumer that hides the SDK iframe/container with `display:none` until `loaded`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
